### PR TITLE
Fix Module jakarta.activation not found, required by org.jvnet.staxex

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -12,7 +12,7 @@ module org.jvnet.staxex {
     requires java.logging;
     requires java.xml.bind;
 
-    requires transitive jakarta.activation;
+    requires transitive javax.activation;
     requires transitive java.xml;
     exports org.jvnet.staxex;
     exports org.jvnet.staxex.util;


### PR DESCRIPTION
This is a pull request for #22 