### PR TITLE
jdk11 and OSGi related fixes

### DIFF
--- a/etc/config/copyright-exclude
+++ b/etc/config/copyright-exclude
@@ -33,5 +33,6 @@
 .svn
 /CONTRIBUTING.md
 /LICENSE.md
+/NOTICE.md
 /etc/config/copyright-exclude
 /src/main/resources/META-INF/LICENSE.md

--- a/pom.xml
+++ b/pom.xml
@@ -263,7 +263,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <doclint>none</doclint>
                     <release>11</release>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -70,9 +70,15 @@
     </mailingLists>
 
     <properties>
-        <findbugs.exclude />
-        <findbugs.skip>false</findbugs.skip>
-        <findbugs.threshold>Low</findbugs.threshold>
+        <copyright.exclude>${config.dir}/copyright-exclude</copyright.exclude>
+        <copyright.ignoreyear>false</copyright.ignoreyear>
+        <copyright.scmonly>true</copyright.scmonly>
+        <copyright.template>${config.dir}/edl-copyright.txt</copyright.template>
+        <copyright.update>false</copyright.update>
+        <spotbugs.skip>false</spotbugs.skip>
+        <spotbugs.threshold>Low</spotbugs.threshold>
+        <spotbugs.version>3.1.11</spotbugs.version>
+
         <config.dir>${project.basedir}/etc/config</config.dir>
         <legal.doc.source>${project.basedir}</legal.doc.source>
     </properties>
@@ -82,11 +88,14 @@
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
             <version>1.2.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
             <version>2.3.2</version>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -109,12 +118,17 @@
                     <version>3.8.0</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M3</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
@@ -122,33 +136,17 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>3.0.5</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.glassfish.findbugs</groupId>
-                            <artifactId>findbugs</artifactId>
-                            <version>1.7</version>
-                        </dependency>
-                    </dependencies>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${spotbugs.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>1.50</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>cobertura-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -158,7 +156,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>4.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -192,7 +190,7 @@
                         <requireMavenVersion>
                             <version>[3.0.3,)</version>
                         </requireMavenVersion>
-                        <!--<DependencyConvergence />-->
+                        <dependencyConvergence />
                     </rules>
                 </configuration>
             </plugin>
@@ -243,11 +241,20 @@
                             <goal>compile</goal>
                         </goals>
                         <configuration>
-                            <source>7</source>
-                            <target>7</target>
+                            <release>7</release>
                             <excludes>
                                 <exclude>module-info.java</exclude>
                             </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!--compile test classes with source/target 7-->
+                        <id>default-testCompile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <release>7</release>
                         </configuration>
                     </execution>
                 </executions>
@@ -256,19 +263,17 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <doclint>none</doclint>
+                    <release>11</release>
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>
-                    <skip>${findbugs.skip}</skip>
-                    <threshold>${findbugs.threshold}</threshold>
+                    <skip>${spotbugs.skip}</skip>
+                    <threshold>${spotbugs.threshold}</threshold>
                     <findbugsXmlWithMessages>true</findbugsXmlWithMessages>
-                    <excludeFilterFile>
-                        exclude-common.xml,${findbugs.exclude}
-                    </excludeFilterFile>
                     <fork>true</fork>
                     <jvmArgs>-Xms64m -Xmx256m</jvmArgs>
                 </configuration>
@@ -277,40 +282,23 @@
                 <groupId>org.glassfish.copyright</groupId>
                 <artifactId>glassfish-copyright-maven-plugin</artifactId>
                 <configuration>
-                    <templateFile>${config.dir}/edl-copyright.txt</templateFile>
-                    <excludeFile>${config.dir}/copyright-exclude</excludeFile>
-                    <scm>git</scm>
+                    <templateFile>${copyright.template}</templateFile>
+                    <excludeFile>${copyright.exclude}</excludeFile>
                     <!-- skip files not under SCM-->
-                    <scmOnly>true</scmOnly>
-                    <!-- turn off warnings -->
-                    <warn>true</warn>
+                    <scmOnly>${copyright.scmonly}</scmOnly>
                     <!-- for use with repair -->
-                    <update>false</update>
+                    <update>${copyright.update}</update>
                     <!-- check that year is correct -->
-                    <ignoreYear>false</ignoreYear>
+                    <ignoreYear>${copyright.ignoreyear}</ignoreYear>
                 </configuration>
                 <executions>
                     <execution>
                         <phase>validate</phase>
                         <goals>
-                            <goal>copyright</goal>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <configuration>
-                    <formats>
-                        <format>xml</format>
-                    </formats>
-                    <check>
-                        <totalLineRate>0</totalLineRate>
-                        <packageLineRate>0</packageLineRate>
-                        <haltOnFailure>true</haltOnFailure>
-                    </check>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -318,7 +306,6 @@
                 <configuration>
                     <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
                     <timestampFormat>{0,date,yyyy-MM-dd'T'HH:mm:ssZ}</timestampFormat>
-                    <getRevisionOnlyOnce>true</getRevisionOnlyOnce>
                     <revisionOnScmFailure>false</revisionOnScmFailure>
                     <shortRevisionLength>7</shortRevisionLength>
                 </configuration>
@@ -354,20 +341,55 @@
                         </goals>
                         <configuration>>
                             <instructions>
-                                <Implementation-Build-Id>${project.version}-${buildNumber}, ${timestamp}</Implementation-Build-Id>
+                                <Implementation-Build-Id>${project.version} - ${scmBranch}-${buildNumber}, ${timestamp}</Implementation-Build-Id>
                                 <_noee>true</_noee>
+                                <Import-Package>
+                                    javax.activation;version=!,
+                                    javax.xml.bind.attachment;version=!,
+                                    *
+                                </Import-Package>
                             </instructions>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <configuration>
-                    <retryFailedDeploymentCount>10</retryFailedDeploymentCount>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jacoco</groupId>
+                            <artifactId>jacoco-maven-plugin</artifactId>
+                            <version>0.8.3</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>default-report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
                             <goal>testCompile</goal>
                         </goals>
                         <configuration>
-                            <release>7</release>
+                            <release>11</release>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +10,7 @@
 
 module org.jvnet.staxex {
     requires java.logging;
-    requires java.xml.bind;
+    requires static java.xml.bind;
 
     requires transitive jakarta.activation;
     requires transitive java.xml;

--- a/src/test/java/org/jvnet/staxex/util/ByteCodeVersionTest.java
+++ b/src/test/java/org/jvnet/staxex/util/ByteCodeVersionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.jvnet.staxex.util;
+
+import java.io.DataInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author lukas
+ */
+public class ByteCodeVersionTest {
+
+    public ByteCodeVersionTest() {
+    }
+
+    @Test
+    public void testModuleInfoByteCodeVersion() {
+        // module-info for JDK 9
+        verifyClassFileFormat("/module-info.class", 0x35);
+    }
+
+    @Test
+    public void testClassByteCodeVersion() {
+        // class files for JDK 7
+        verifyClassFileFormat("/org/jvnet/staxex/MtomEnabled.class", 0x33);
+    }
+    
+    private static void verifyClassFileFormat(String resource, int expectedClassVersion) {
+        try (InputStream in = ByteCodeVersionTest.class.getModule().getResourceAsStream(resource);
+                DataInputStream data = new DataInputStream(in)) {
+            if (0xCAFEBABE != data.readInt()) {
+                Assert.fail("invalid header");
+            }
+            // minor
+            int i = data.readUnsignedShort();
+            // major
+            i = data.readUnsignedShort();
+            Assert.assertEquals("Class Files compiled for wrong java runtime version", expectedClassVersion, i);
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+    }
+}


### PR DESCRIPTION
various fixes:
* updated copyright plugin/fixed exclusions list
* replaced cobertura with jacoco and moved coverage to extra profile
* replaced findbugs with spotbugs
* updated felix bundle plugin and fixed dependencies, so they are properly unversioned (activation) and optional (jaxb api)

Signed-off-by: Lukas Jungmann <lukas.jungmann@oracle.com>