### PR TITLE
[#29] Update to Jakarta EE 9 dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -87,13 +87,13 @@
         <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
-            <version>1.2.1</version>
+            <version>2.0.0-rc1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>2.3.2</version>
+            <version>3.0.0-RC1</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>
@@ -323,12 +323,12 @@
                         <goals>
                             <goal>manifest</goal>
                         </goals>
-                        <configuration>>
+                        <configuration>
                             <instructions>
                                 <Implementation-Build-Id>${project.version} - ${scmBranch}-${buildNumber}, ${timestamp}</Implementation-Build-Id>
                                 <Import-Package>
-                                    javax.activation;version=!,
-                                    javax.xml.bind.attachment;version=!,
+                                    jakarta.activation;version=!,
+                                    jakarta.xml.bind.attachment;version=!,
                                     *
                                 </Import-Package>
                             </instructions>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +10,7 @@
 
 module org.jvnet.staxex {
     requires java.logging;
-    requires static java.xml.bind;
+    requires static jakarta.xml.bind;
 
     requires transitive jakarta.activation;
     requires transitive java.xml;

--- a/src/main/java/org/jvnet/staxex/Base64Data.java
+++ b/src/main/java/org/jvnet/staxex/Base64Data.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,8 +10,8 @@
 
 package org.jvnet.staxex;
 
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
+import jakarta.activation.DataHandler;
+import jakarta.activation.DataSource;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
 //import com.sun.xml.stream.writers.XMLStreamWriterImpl;
 //import java.io.FileNotFoundException;
 //import java.io.FileWriter;
-//import javax.activation.FileDataSource;
+//import jakarta.activation.FileDataSource;
 
 /**
  * Binary data represented as base64-encoded string

--- a/src/main/java/org/jvnet/staxex/BinaryText.java
+++ b/src/main/java/org/jvnet/staxex/BinaryText.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +10,7 @@
 
 package org.jvnet.staxex;
 
-import javax.activation.DataHandler;
+import jakarta.activation.DataHandler;
 
 /**
  * BinaryText represents a MTOM attachment.

--- a/src/main/java/org/jvnet/staxex/MtomEnabled.java
+++ b/src/main/java/org/jvnet/staxex/MtomEnabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +10,7 @@
 
 package org.jvnet.staxex;
 
-import javax.activation.DataHandler;
+import jakarta.activation.DataHandler;
 
 /**
  * A SOAPElement implementation may support this interface to allow MTOM attachments.

--- a/src/main/java/org/jvnet/staxex/StreamingDataHandler.java
+++ b/src/main/java/org/jvnet/staxex/StreamingDataHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,8 +10,8 @@
 
 package org.jvnet.staxex;
 
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
+import jakarta.activation.DataHandler;
+import jakarta.activation.DataSource;
 import java.io.BufferedInputStream;
 import java.io.Closeable;
 import java.io.File;

--- a/src/main/java/org/jvnet/staxex/XMLStreamWriterEx.java
+++ b/src/main/java/org/jvnet/staxex/XMLStreamWriterEx.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +10,7 @@
 
 package org.jvnet.staxex;
 
-import javax.activation.DataHandler;
+import jakarta.activation.DataHandler;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import java.io.OutputStream;

--- a/src/main/java/org/jvnet/staxex/util/MtomStreamWriter.java
+++ b/src/main/java/org/jvnet/staxex/util/MtomStreamWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -10,7 +10,7 @@
 
 package org.jvnet.staxex.util;
 
-import javax.xml.bind.attachment.AttachmentMarshaller;
+import jakarta.xml.bind.attachment.AttachmentMarshaller;
 import javax.xml.stream.XMLStreamWriter;
 
 /**

--- a/src/main/java/org/jvnet/staxex/util/XMLStreamReaderToXMLStreamWriter.java
+++ b/src/main/java/org/jvnet/staxex/util/XMLStreamReaderToXMLStreamWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -12,7 +12,7 @@ package org.jvnet.staxex.util;
 
 import java.io.IOException;
 
-import javax.xml.bind.attachment.AttachmentMarshaller;
+import jakarta.xml.bind.attachment.AttachmentMarshaller;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;


### PR DESCRIPTION
Updates to Jakarta Activation 2.0.0-rc1 and Jakarta JAXB 3.0.0-RC1.

This should resolve issue #29, though we may want to keep 29 open until there are final releases of these dependencies.